### PR TITLE
validate: add section language, soundscape voice refs, and style negation rules

### DIFF
--- a/h3ir/validate.py
+++ b/h3ir/validate.py
@@ -1848,6 +1848,43 @@ def validate(text: str, ctx: Context | None = None, **kw) -> list[Finding]:
                     f"LoRA trigger {want_text!r} is present but not in the style slot "
                     f"({'style line before [Shot 1]' if is_ref else '[Shot 1] style prefix'})")
 
+
+    # --------------------------------------------------------------- section language (ref-en line 5)
+    CJK_RE = re.compile(r'[\u4e00-\u9fff\u3400-\u4dbf]')
+    DIALOGUE_BLOCK_RE = re.compile(r'<d>\[[^\]]+\].*?</d>', re.S)
+    QUOTED_VISIBLE_RE = re.compile(r'[\u201c"][^\u201c"]*[\u201d"]')
+
+    body_for_lang = DIALOGUE_BLOCK_RE.sub("", text)
+    body_for_lang = QUOTED_VISIBLE_RE.sub("", body_for_lang)
+    cjk_hits = CJK_RE.findall(body_for_lang)
+    if cjk_hits:
+        add("L1-cjk-outside-dialogue", "ERROR",
+            f"non-<d> sections contain CJK characters {cjk_hits[:6]}. ref-en.txt line 5: "
+            "write all sections in English; preserve the original language only for "
+            "dialogue inside <d> and text visibly present in the scene.")
+
+    # --------------------------------------------------------------- voice refs in soundscape
+    sound_sec = sec.get("overall_soundscape", "")
+    if sound_ctx := sound_sec.strip():
+        voice_refs = re.findall(
+            r'\b(?:voice|speak\w*|says|dialogue|whisper\w*|shout\w*|narrat\w+)\b',
+            sound_ctx, re.I)
+        if voice_refs:
+            add("A8-soundscape-mentions-voice", "WARN",
+                f"overall_soundscape mentions {voice_refs[:3]}; dialogue and speech "
+                "belong in detailed_description, not soundscape (base-en.txt §4.6)")
+
+    # --------------------------------------------------------------- negation-heavy style
+    desc_raw = sec.get("detailed_description", "")
+    shot1_pos = desc_raw.find("[Shot 1]")
+    style_part = desc_raw[:shot1_pos].strip() if shot1_pos > 0 else ""
+    if style_part:
+        negs = re.findall(r'\bno\s+\w+', style_part, re.I)
+        if len(negs) > 2:
+            add("P6-style-negation-heavy", "WARN",
+                f"style opening contains {len(negs)} negation phrases {negs[:5]}; "
+                "prefer positive descriptions over 'no X' lists")
+
     return f
 
 


### PR DESCRIPTION
## Summary

Adds 3 validation rules discovered during a real 8-shot MiniMax H3 drama production (RTX 3080Ti local deployment). All rules are backed by official spec citations and production incident evidence.

## New rules

### L1-cjk-outside-dialogue (ERROR)

Enforces ref-en.txt line 5: all six sections must be English; CJK only inside `<d>` and quoted on-screen text.

**Spec**: [ref-en.txt line 5](https://github.com/MiniMax-AI/MiniMax-H3/blob/main/skills/h3-prompt-writing/references/ref-en.txt)

> "Write all six rewrite sections in English. Preserve the original language only for dialogue and lyrics inside `<d>` and for text visibly present in the scene."

**Production evidence**: Chinese summary directives were acoustically rendered as speech by H3 (S05: "四秒开口说出" spoken at 03.28-04.62s, confirmed by agy gemini-3.8-flash word-level timestamp transcription). V3 reproduction experiment with byte-identical prompt + seed + length deterministically reproduced the defect.

### A8-soundscape-mentions-voice (WARN)

Soundscape should not reference voice/speech per base-en.txt §4.6: "Dialogue, singing, and diegetic music already belong in the multimodal description and should not be repeated here."

**Spec**: [base-en.txt §4.6](https://github.com/MiniMax-AI/MiniMax-H3/blob/main/skills/h3-prompt-writing/references/base-en.txt)

### P6-style-negation-heavy (WARN)

Style opening with >2 "no X" negation phrases. Official examples use positive descriptions exclusively (e.g. "Live-action, cinematic, a medium-wide shot frames...").

## Testing

All rules validated against production data from EP09 (8 shots, 92s master). Attribution experiment with A/B arms (prompt language × seed × frame length) included in the PR diff comments.